### PR TITLE
remove foot-guns, improve API, conceal conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+
+## Unreleased
+
+
+### Added
+
+-   new `getCake()` function to reduce confusion (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,10 @@
 ### Added
 
 -   new `getCake()` function to reduce confusion (#1)
+
+
+### Changed
+
+-   BREAKING: your `BakeFunction` should resolve with your `Cake` object
+
+-   BREAKING: your `BakeFunction` no longer provided access to `conf`

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ You assume that during a future execution of your script,
 you'll have access to the results of that previous run.
 
 
-### `putInOven(options: HSIPEOptions, ...args: any[])`
+### `putInOven(options: OvenOptions, ...args: any[])`
 
 ```flowtype
-type HSIPEOptions = {
+type OvenOptions = {
   bakePath: string,
   cakeName: string,
   interval?: number
@@ -43,7 +43,25 @@ type BakeOptions = {
 
 -   see upstream [Conf](https://github.com/sindresorhus/conf) for more details
 
--   when your BakeFunction resolves, we automatically set "lastBaked" value in `conf` for you (used when checking **interval**)
+-   when your BakeFunction resolves, we automatically set "lastBaked" value in the cake for you (used when checking **interval**)
+
+
+### `getCake(options: CakeOptions) => Cake`
+
+```flowtype
+type CakeOptions = {
+  cakeName: string
+}
+
+type Cake = {
+  lastBaked?: number,
+  [id:string]: any
+}
+```
+
+-   **cakeName** must be the same cake that you `putInOven()` earlier
+
+-   returns your **Cake** if it's ready (you'll have to check)
 
 
 ### Example
@@ -54,16 +72,16 @@ type BakeOptions = {
 const path = require('path')
 
 const Conf = require('conf')
-const { putInOven } = require('hsipe')
+const { getCake, putInOven } = require('hsipe')
 
 const cakeName = 'strawberry-shortcake'
-const conf = new Conf({ configName: cakeName })
 
 // start baking our strawberry-shortcake
 putInOven({ bakePath: path.join(__dirname, 'bake.js'), cakeName })
 
 // try to continue on, in case we already started baking last time
-const flavour = conf.get('flavour')
+const cake = getCake({ cakeName })
+const flavour = cake.flavour
 
 if (flavour) {
   // yay, we must have prepared something earlier

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ type OvenOptions = {
   cakeName: string,
   interval?: number
 }
+
+type Cake = {
+  lastBaked?: number,
+  [id:string]: any
+}
 ```
 
 -   **bakePath** is a path to a module that exports a BakeFunction named "bake"
@@ -35,15 +40,18 @@ type OvenOptions = {
 
 
 ```flowtype
-type BakeFunction = (options: BakeOptions, ...args: any[]) => Promise<void>
+type BakeFunction = (...args: any[]) => Promise<Cake>
 type BakeOptions = {
-  conf: Conf
+  cake: Cake
 }
 ```
 
--   see upstream [Conf](https://github.com/sindresorhus/conf) for more details
+-   your `BakeFunction` has access to the previous `Cake`,
+  which could be useful for more-efficient / partial baking
 
--   when your BakeFunction resolves, we automatically set "lastBaked" value in the cake for you (used when checking **interval**)
+-   your `BakeFunction` resolves with your `Cake`,
+  and we automatically set "lastBaked" value in the `Cake` for you
+  (used when checking **interval**)
 
 
 ### `getCake(options: CakeOptions) => Cake`
@@ -51,11 +59,6 @@ type BakeOptions = {
 ```flowtype
 type CakeOptions = {
   cakeName: string
-}
-
-type Cake = {
-  lastBaked?: number,
-  [id:string]: any
 }
 ```
 
@@ -96,12 +99,11 @@ if (flavour) {
 [bake.js](./example/bake.js):
 
 ```js
-function bake ({ conf }, ...args) {
+function bake ({ cake }, ...args) {
   // e.g. something that can take a while to finish
   return new Promise((resolve) => {
     setTimeout(() => {
-      conf.set('flavour', 'delicious')
-      resolve()
+      resolve({ flavour: delicious })
     }, 5e3)
   })
 }

--- a/__tests__/fixtures/bake-function-args.js
+++ b/__tests__/fixtures/bake-function-args.js
@@ -2,20 +2,18 @@
 'use strict'
 
 /* ::
-import type { BakeOptions } from '../../index.js'
+import type { BakeOptions, Cake } from '../../index.js'
 */
 
 function bake (
   options /* : BakeOptions */,
   customArg1 /* : string */,
   customArg2 /* : number */
-) /* : Promise<void> */ {
-  const conf = options.conf
+) /* : Promise<Cake> */ {
+  // const cake = options.cake
+  // const args = arguments.slice(1)
 
-  conf.set('customArg1', customArg1)
-  conf.set('customArg2', customArg2)
-
-  return Promise.resolve()
+  return Promise.resolve({ customArg1, customArg2 })
 }
 
 module.exports = { bake }

--- a/__tests__/fixtures/resolve.js
+++ b/__tests__/fixtures/resolve.js
@@ -2,11 +2,11 @@
 'use strict'
 
 /* ::
-import type { BakeOptions } from '../../index.js'
+import type { BakeOptions, Cake } from '../../index.js'
 */
 
-function bake (options /* : BakeOptions */) /* : Promise<void> */ {
-  return Promise.resolve()
+function bake (options /* : BakeOptions */) /* : Promise<Cake> */ {
+  return Promise.resolve({})
 }
 
 module.exports = { bake }

--- a/__tests__/put-in-oven.js
+++ b/__tests__/put-in-oven.js
@@ -10,39 +10,42 @@ const getCake = require('../index.js').getCake
 const putInOven = require('../index.js').putInOven
 
 let cakeName
-let cake
 let conf
 beforeEach(() => {
   cakeName = Math.floor(Math.random() * 1e6) + '-' + (new Date()).valueOf()
-  cake = getCake({ cakeName })
   conf = new Conf({ configName: cakeName })
 })
 afterEach(() => {
   idemFs.unlinkSync(conf.path)
-  cake = null
+  conf = null
 })
 
 test('putInOven() no options', () => {
   expect(() => putInOven()).toThrow()
+  let cake = getCake({ cakeName })
   expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ bakePath }) no cakeName', () => {
   expect(() => putInOven({ bakePath: './bake.js' })).toThrow()
+  let cake = getCake({ cakeName })
   expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ cakeName }) no bakePath', () => {
   expect(() => putInOven({ cakeName })).toThrow()
+  let cake = getCake({ cakeName })
   expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ bakePath, cakeName })', () => {
   const bakePath = fixturePath('resolve')
   expect(() => putInOven({ bakePath, cakeName })).not.toThrow()
+  let cake = getCake({ cakeName })
   expect(cake.lastBaked).toBeUndefined()
   return delay(250)
     .then(() => {
+      cake = getCake({ cakeName })
       expect(typeof cake.lastBaked).toEqual('number')
     })
 })
@@ -54,10 +57,11 @@ test('putInOven({ bakePath, cakeName }, ...args)', () => {
   expect(() => {
     putInOven({ bakePath, cakeName }, customArg1, customArg2)
   }).not.toThrow()
+  let cake = getCake({ cakeName })
   expect(cake.lastBaked).toBeUndefined()
   return delay(250)
     .then(() => {
-      const cake = getCake({ cakeName })
+      cake = getCake({ cakeName })
       expect(cake.customArg1).toEqual(customArg1)
       expect(cake.customArg2).toEqual(customArg2)
       expect(typeof cake.lastBaked).toEqual('number')

--- a/__tests__/put-in-oven.js
+++ b/__tests__/put-in-oven.js
@@ -6,41 +6,44 @@ const idemFs = require('idempotent-fs')
 
 const fixturePath = require('./helpers/paths.js').fixturePath
 const delay = require('./helpers/promises.js').delay
+const getCake = require('../index.js').getCake
 const putInOven = require('../index.js').putInOven
 
 let cakeName
+let cake
 let conf
 beforeEach(() => {
   cakeName = Math.floor(Math.random() * 1e6) + '-' + (new Date()).valueOf()
-  conf = new Conf({ configName: cakeName, projectName: 'hsipe' })
+  cake = getCake({ cakeName })
+  conf = new Conf({ configName: cakeName })
 })
 afterEach(() => {
   idemFs.unlinkSync(conf.path)
-  conf = null
+  cake = null
 })
 
 test('putInOven() no options', () => {
   expect(() => putInOven()).toThrow()
-  expect(conf.get('lastBaked')).toBeUndefined()
+  expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ bakePath }) no cakeName', () => {
   expect(() => putInOven({ bakePath: './bake.js' })).toThrow()
-  expect(conf.get('lastBaked')).toBeUndefined()
+  expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ cakeName }) no bakePath', () => {
   expect(() => putInOven({ cakeName })).toThrow()
-  expect(conf.get('lastBaked')).toBeUndefined()
+  expect(cake.lastBaked).toBeUndefined()
 })
 
 test('putInOven({ bakePath, cakeName })', () => {
   const bakePath = fixturePath('resolve')
   expect(() => putInOven({ bakePath, cakeName })).not.toThrow()
-  expect(conf.get('lastBaked')).toBeUndefined()
+  expect(cake.lastBaked).toBeUndefined()
   return delay(250)
     .then(() => {
-      expect(typeof conf.get('lastBaked')).toEqual('number')
+      expect(typeof cake.lastBaked).toEqual('number')
     })
 })
 
@@ -51,11 +54,12 @@ test('putInOven({ bakePath, cakeName }, ...args)', () => {
   expect(() => {
     putInOven({ bakePath, cakeName }, customArg1, customArg2)
   }).not.toThrow()
-  expect(conf.get('lastBaked')).toBeUndefined()
+  expect(cake.lastBaked).toBeUndefined()
   return delay(250)
     .then(() => {
-      expect(conf.get('customArg1')).toEqual(customArg1)
-      expect(conf.get('customArg2')).toEqual(customArg2)
-      expect(typeof conf.get('lastBaked')).toEqual('number')
+      const cake = getCake({ cakeName })
+      expect(cake.customArg1).toEqual(customArg1)
+      expect(cake.customArg2).toEqual(customArg2)
+      expect(typeof cake.lastBaked).toEqual('number')
     })
 })

--- a/example/bake.js
+++ b/example/bake.js
@@ -2,18 +2,17 @@
 'use strict'
 
 /* ::
-import type { BakeOptions } from '../index.js'
+import type { BakeOptions, Cake } from '../index.js'
 */
 
-function bake (options /* : BakeOptions */) /* : Promise<void> */ {
-  const conf = options.conf
+function bake (options /* : BakeOptions */) /* : Promise<Cake> */ {
+  // const cake = options.cake
   // const args = arguments.slice(1)
 
   // e.g. something that can take a while to finish
   return new Promise((resolve) => {
     setTimeout(() => {
-      conf.set('flavour', 'delicious')
-      resolve()
+      resolve({ flavour: 'delicious' })
     }, 5e3)
   })
 }

--- a/example/index.js
+++ b/example/index.js
@@ -3,11 +3,10 @@
 
 const path = require('path')
 
-const Conf = require('conf')
+const getCake = require('../index.js').getCake
 const putInOven = require('../index.js').putInOven
 
 const cakeName = 'strawberry-shortcake'
-const conf = new Conf({ configName: cakeName })
 
 // start baking our strawberry-shortcake
 putInOven({
@@ -16,7 +15,8 @@ putInOven({
 })
 
 // try to continue on, in case we already started baking last time
-const flavour = conf.get('flavour')
+const cake = getCake({ cakeName })
+const flavour = cake.flavour
 
 if (flavour) {
   // yay, we must have prepared something earlier

--- a/index.js
+++ b/index.js
@@ -12,9 +12,13 @@ export type OvenOptions = {
   cakeName: string,
   interval?: number
 }
+export type Cake = {
+  lastBaked?: number,
+  [id:string]: any
+}
 export type BakeFunction = (options: BakeOptions, ...args: any[]) => Promise<void>
 export type BakeOptions = {
-  conf: { [id:string]: any }
+  cake: Cake
 }
 */
 

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
 const path = require('path')
 const spawn = require('child_process').spawn
 
-const Conf = require('conf')
+const cake = require('./lib/cake.js')
 
 /* ::
-export type HSIPEOptions = {
+export type OvenOptions = {
   bakePath: string,
   cakeName: string,
   interval?: number
@@ -24,7 +24,7 @@ function isValidString (string) {
   return typeof string === 'string' && string
 }
 
-function putInOven (options /* : HSIPEOptions */) {
+function putInOven (options /* : OvenOptions */) {
   if (!options || typeof options !== 'object') {
     throw new TypeError('options object is mandatory')
   }
@@ -32,7 +32,7 @@ function putInOven (options /* : HSIPEOptions */) {
   const bakePath = options.bakePath
   const cakeName = options.cakeName
 
-  const conf = new Conf({ configName: cakeName, projectName: 'hsipe' })
+  const conf = cake.getConf({ cakeName })
 
   if (!isValidString(bakePath) || !isValidString(cakeName)) {
     throw new TypeError('bakePath and cakeName strings are mandatory')
@@ -65,5 +65,6 @@ function putInOven (options /* : HSIPEOptions */) {
 }
 
 module.exports = {
+  getCake: cake.getCake,
   putInOven
 }

--- a/lib/cake.js
+++ b/lib/cake.js
@@ -1,0 +1,23 @@
+/* @flow */
+'use strict'
+
+const Conf = require('conf')
+
+/* ::
+export type CakeOptions = {
+  cakeName: string
+}
+*/
+
+function getConf (options /* : CakeOptions */) {
+  return new Conf({ configName: options.cakeName })
+}
+
+function getCake (options /* : CakeOptions */) {
+  return getConf(options).store
+}
+
+module.exports = {
+  getConf,
+  getCake
+}

--- a/lib/start-baking.js
+++ b/lib/start-baking.js
@@ -1,12 +1,12 @@
 /* @flow */
 'use strict'
 
-const Conf = require('conf')
+const cake = require('./cake.js')
 
 const data = JSON.parse(process.argv[2])
 const options = data[0]
 
-const conf = new Conf({ configName: options.cakeName, projectName: 'hsipe' })
+const conf = cake.getConf({ cakeName: options.cakeName })
 // $FlowFixMe: need to require() a dynamic path, that is the whole point
 const bakeFunction = require(options.bakePath).bake
 

--- a/lib/start-baking.js
+++ b/lib/start-baking.js
@@ -1,18 +1,21 @@
 /* @flow */
 'use strict'
 
-const cake = require('./cake.js')
+const getCake = require('./cake.js').getCake
+const getConf = require('./cake.js').getConf
 
 const data = JSON.parse(process.argv[2])
 const options = data[0]
 
-const conf = cake.getConf({ cakeName: options.cakeName })
+const conf = getConf({ cakeName: options.cakeName })
+const oldCake = getCake({ cakeName: options.cakeName })
+
 // $FlowFixMe: need to require() a dynamic path, that is the whole point
 const bakeFunction = require(options.bakePath).bake
 
-bakeFunction.apply(null, [ { conf } ].concat(data[1]))
-  .then(() => {
-    conf.set('lastBaked', Date.now())
+bakeFunction.apply(null, [ { cake: oldCake } ].concat(data[1]))
+  .then((newCake) => {
+    conf.store = Object.assign({}, newCake, { lastBaked: Date.now() })
 
     // Call process exit explicitly to terminate the child process
     // Otherwise the child process will run forever (according to nodejs docs)


### PR DESCRIPTION
### Added

-   new `getCake()` function to reduce confusion (#1)


### Changed

-   BREAKING: your `BakeFunction` should resolve with your `Cake` object

-   BREAKING: your `BakeFunction` no longer provided access to `conf` (fixes #1)
